### PR TITLE
fix: Resolve JS error and improve a11y in Golden Tables tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -440,7 +440,7 @@
                 <!-- Golden Table Selection -->
                 <div class="card">
                     <div class="card-content">
-                        <label for="goldenTableSelector" class="block text-sm font-medium mb-2">Select a Golden Table</label>
+                        <label for="goldenTableSelectorTrigger" class="block text-sm font-medium mb-2">Select a Golden Table</label>
                         <div class="select-wrapper">
                             <button class="select-trigger" id="goldenTableSelectorTrigger">
                                 <span id="goldenTableSelectorValue">Select a table...</span>
@@ -466,14 +466,14 @@
                                 <div class="flex items-center gap-4 mb-4">
                                     <div class="flex-grow">
                                         <label for="startDate" class="block text-sm font-medium mb-1">Start Date</label>
-                                        <input type="date" id="startDate" class="input">
+                                        <input type="date" id="startDate" name="startDate" class="input">
                                     </div>
                                     <div class="flex-grow">
                                         <label for="endDate" class="block text-sm font-medium mb-1">End Date</label>
-                                        <input type="date" id="endDate" class="input">
+                                        <input type="date" id="endDate" name="endDate" class="input">
                                     </div>
                                     <div>
-                                        <label for="datePreset" class="block text-sm font-medium mb-1">Presets</label>
+                                        <label for="datePresetTrigger" class="block text-sm font-medium mb-1">Presets</label>
                                         <div class="select-wrapper">
                                             <button class="select-trigger" id="datePresetTrigger">
                                                 <span id="datePresetValue">Select...</span>

--- a/script.js
+++ b/script.js
@@ -941,11 +941,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Call initialization function when the golden tab is shown
     const goldenTabTrigger = document.querySelector('.tabs-trigger[data-tab="golden"]');
-    let goldenTabInitialized = false;
     goldenTabTrigger.addEventListener('click', () => {
-        if (!goldenTabInitialized) {
-            initializeGoldenTablesTab();
-            goldenTabInitialized = true;
-        }
+        initializeGoldenTablesTab();
     });
 });


### PR DESCRIPTION
This commit resolves a JavaScript error that occurred when switching to the Golden Tables tab by removing a problematic check. It also improves accessibility by adding `for` attributes to labels in the tab.