### PR TITLE
feat: Implement query drawer with stubbed results

### DIFF
--- a/index.html
+++ b/index.html
@@ -233,6 +233,17 @@
                 </div>
         </div>
 
+        <div id="query-drawer" class="drawer">
+            <div class="drawer-header">
+                <h2 id="query-drawer-title" class="drawer-title">Query Details</h2>
+                <button id="query-drawer-close" class="drawer-close">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-x h-5 w-5"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+                </button>
+            </div>
+            <div id="query-drawer-content" class="drawer-content">
+            </div>
+        </div>
+
         <div class="text-center mb-8">
             <h1 class="text-3xl font-bold mb-2">Intelligent RRR Value Analysis</h1>
             <p class="text-gray-600">AI-powered risk reduction assessment for project planning</p>
@@ -425,6 +436,16 @@
                                     RAG system combines structured BQ data with document embeddings for contextual recommendations. Documents are automatically indexed from SharePoint with real-time updates.
                                 </p>
                             </div>
+                        </div>
+                    </div>
+                </div>
+                <div id="query-results-container" class="hidden">
+                    <div class="card">
+                        <div class="card-header">
+                            <h3 class="card-title">Query Results</h3>
+                        </div>
+                        <div class="card-content">
+                            <div id="query-results-table"></div>
                         </div>
                     </div>
                 </div>

--- a/script.js
+++ b/script.js
@@ -480,6 +480,65 @@ document.addEventListener('DOMContentLoaded', () => {
 
     drawerClose.addEventListener('click', closeDrawer);
 
+    const queryDrawer = document.getElementById('query-drawer');
+    const queryDrawerClose = document.getElementById('query-drawer-close');
+
+    function openQueryDrawer(query) {
+        const queryDrawerContent = document.getElementById('query-drawer-content');
+        queryDrawerContent.innerHTML = `
+            <div class="space-y-4">
+                <div>
+                    <h4 class="font-medium text-sm text-gray-500">Plain Language Query</h4>
+                    <p>${query}</p>
+                </div>
+                <div>
+                    <label for="sql-query-input" class="block text-sm font-medium mb-1">BigQuery SQL</label>
+                    <textarea id="sql-query-input" class="textarea" rows="5">SELECT * FROM \`${selectedGoldenTable.name}\` WHERE ...</textarea>
+                </div>
+                <button id="submit-sql-query-btn" class="button primary w-full">Submit Query</button>
+            </div>
+        `;
+        queryDrawer.classList.add('open');
+
+        document.getElementById('submit-sql-query-btn').addEventListener('click', () => {
+            queryDrawer.classList.remove('open');
+            displayQueryResults();
+        });
+    }
+
+    function displayQueryResults() {
+        const resultsContainer = document.getElementById('query-results-container');
+        const resultsTable = document.getElementById('query-results-table');
+
+        const headers = selectedGoldenTable.columns.map(c => c.name);
+        let tableHtml = `
+            <table class="w-full text-sm text-left">
+                <thead class="bg-gray-50">
+                    <tr>
+                        ${headers.map(h => `<th class="p-2 font-medium">${h}</th>`).join('')}
+                    </tr>
+                </thead>
+                <tbody>
+        `;
+        for (let i = 0; i < 5; i++) {
+            tableHtml += '<tr class="border-b">';
+            headers.forEach(h => {
+                tableHtml += `<td class="p-2">Value ${i+1}</td>`;
+            });
+            tableHtml += '</tr>';
+        }
+        tableHtml += '</tbody></table>';
+
+        resultsTable.innerHTML = tableHtml;
+        resultsContainer.classList.remove('hidden');
+    }
+
+    function closeQueryDrawer() {
+        queryDrawer.classList.remove('open');
+    }
+
+    queryDrawerClose.addEventListener('click', closeQueryDrawer);
+
     function handleChatbotSend() {
         const input = document.getElementById('chatbot-input');
         const messagesContainer = document.getElementById('chatbot-messages');
@@ -825,7 +884,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 alert("Please select a golden table first.");
                 return;
             }
-            alert(`Executing query on ${selectedGoldenTable.name}: "${queryTextarea.value}"`);
+            openQueryDrawer(queryTextarea.value);
         });
 
         querySuggestions.addEventListener('click', (e) => {


### PR DESCRIPTION
This commit implements a drawer that appears when a plain language query is executed. The drawer displays the original query, an editable BigQuery SQL query, and a submit button. When the submit button is clicked, a stubbed results table is displayed.